### PR TITLE
Implement MVVM with DevExpress

### DIFF
--- a/source/MainWindow.xaml
+++ b/source/MainWindow.xaml
@@ -41,7 +41,7 @@
                         Padding="0,0,0,0"
                         VerticalAlignment="Top"
                         BorderThickness="0"
-                        Click="btnFileNew_Click">
+                        Command="{Binding NewCommand}">
                         <StackPanel>
                             <Image
                                 Width="32"

--- a/source/MainWindow.xaml.cs
+++ b/source/MainWindow.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using DevExpress.Xpf.Core;
 using DevExpress.Xpf.Ribbon;
+using Pulse.PLMSuite.ViewModels;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -24,11 +25,7 @@ namespace Pulse.PLMSuite
         public MainWindow()
         {
             InitializeComponent();
-        }
-
-        private void btnFileNew_Click(object sender, RoutedEventArgs e)
-        {
-
+            DataContext = new MainWindowViewModel();
         }
     }
 }

--- a/source/ViewModels/MainWindowViewModel.cs
+++ b/source/ViewModels/MainWindowViewModel.cs
@@ -1,0 +1,21 @@
+using DevExpress.Mvvm;
+using System.Windows;
+
+namespace Pulse.PLMSuite.ViewModels
+{
+    public class MainWindowViewModel : ViewModelBase
+    {
+        public DelegateCommand NewCommand { get; }
+
+        public MainWindowViewModel()
+        {
+            NewCommand = new DelegateCommand(OnNew);
+        }
+
+        private void OnNew()
+        {
+            // TODO: Implement new action logic
+            MessageBox.Show("New command executed", "Info");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `MainWindowViewModel` with a `DelegateCommand`
- bind the New button in `MainWindow.xaml` to the new command
- set the DataContext of `MainWindow` to use the ViewModel and remove the event handler
- ensure `DevExpress.Mvvm.v21.2` reference is present

## Testing
- `dotnet build CadModeller.csproj -nologo` *(fails: `dotnet` not found)*
- `msbuild /version` *(fails: command not found)*