### PR TITLE
Introduce custom Viewport controls

### DIFF
--- a/source/Controls/Viewport2D.cs
+++ b/source/Controls/Viewport2D.cs
@@ -1,0 +1,35 @@
+using devDept.Eyeshot.Control;
+using System.Windows.Input;
+
+namespace Pulse.PLMSuite.Modeller.Controls
+{
+    /// <summary>
+    /// Customized Eyeshot Drawing control with additional behavior.
+    /// </summary>
+    public class Viewport2D : Drawing
+    {
+        /// <summary>
+        /// Resets the active view by performing a ZoomFit.
+        /// </summary>
+        public void ResetView()
+        {
+            ZoomFit();
+        }
+
+        /// <summary>
+        /// Overrides the preview key handling to provide a Ctrl+R shortcut
+        /// for resetting the view.
+        /// </summary>
+        /// <param name="e">Key event data.</param>
+        protected override void OnPreviewKeyDown(KeyEventArgs e)
+        {
+            base.OnPreviewKeyDown(e);
+
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.R)
+            {
+                ResetView();
+                e.Handled = true;
+            }
+        }
+    }
+}

--- a/source/Controls/Viewport3d.cs
+++ b/source/Controls/Viewport3d.cs
@@ -1,0 +1,35 @@
+using devDept.Eyeshot.Control;
+using System.Windows.Input;
+
+namespace Pulse.PLMSuite.Modeller.Controls
+{
+    /// <summary>
+    /// Customized Eyeshot Design control with additional behavior.
+    /// </summary>
+    public class Viewport3d : Design
+    {
+        /// <summary>
+        /// Resets the active view by performing a ZoomFit.
+        /// </summary>
+        public void ResetView()
+        {
+            ZoomFit();
+        }
+
+        /// <summary>
+        /// Overrides the preview key handling to provide a Ctrl+R shortcut
+        /// for resetting the view.
+        /// </summary>
+        /// <param name="e">Key event data.</param>
+        protected override void OnPreviewKeyDown(KeyEventArgs e)
+        {
+            base.OnPreviewKeyDown(e);
+
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.R)
+            {
+                ResetView();
+                e.Handled = true;
+            }
+        }
+    }
+}

--- a/source/Views/MainWindow.xaml
+++ b/source/Views/MainWindow.xaml
@@ -12,6 +12,7 @@
     xmlns:dxg="http://schemas.devexpress.com/winfx/2008/xaml/grid"
     xmlns:dxr="http://schemas.devexpress.com/winfx/2008/xaml/ribbon"
     xmlns:local="clr-namespace:Pulse.PLMSuite.Modeller.Views"
+    xmlns:ctrl="clr-namespace:Pulse.PLMSuite.Modeller.Controls"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     Title="Pulse PLM | Modeller"
     Width="1024"
@@ -779,7 +780,7 @@
                                      ShowTabHeaders="False" >
                     <dxd:DocumentPanel Caption="Model Name">
                         <Grid>
-                            <ddes:Design>
+                            <ctrl:Viewport3d>
                                 <ddes:Design.ViewportBorder>
                                     <ddes:BorderSettings Visible="False" />
                                 </ddes:Design.ViewportBorder>
@@ -834,7 +835,7 @@
                                         </ddes:Viewport.ViewCubeIcon>
                                     </ddes:Viewport>
                                 </ddes:Design.Viewports>
-                            </ddes:Design>
+                            </ctrl:Viewport3d>
                         </Grid>
                     </dxd:DocumentPanel>
                 </dxd:DocumentGroup>


### PR DESCRIPTION
## Summary
- rename `CustomDesign` to `Viewport3d`
- add new `Viewport2D` control for Eyeshot Drawing
- switch `MainWindow.xaml` to use `Viewport3d`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683afd3d609c832e9dea7cb599da8212