### PR TITLE
Add new document dialog

### DIFF
--- a/source/DocumentType.cs
+++ b/source/DocumentType.cs
@@ -1,0 +1,9 @@
+namespace Pulse.PLMSuite
+{
+    public enum DocumentType
+    {
+        Part,
+        Assembly,
+        Drawing
+    }
+}

--- a/source/Services/INewDocumentDialogService.cs
+++ b/source/Services/INewDocumentDialogService.cs
@@ -1,0 +1,8 @@
+using Pulse.PLMSuite;
+namespace Pulse.PLMSuite.Services
+{
+    public interface INewDocumentDialogService
+    {
+        DocumentType? ShowDialog();
+    }
+}

--- a/source/Services/NewDocumentDialogService.cs
+++ b/source/Services/NewDocumentDialogService.cs
@@ -1,0 +1,24 @@
+using Pulse.PLMSuite;
+using Pulse.PLMSuite.Modeller.Views;
+using Pulse.PLMSuite.ViewModels;
+
+namespace Pulse.PLMSuite.Services
+{
+    public class NewDocumentDialogService : INewDocumentDialogService
+    {
+        public DocumentType? ShowDialog()
+        {
+            var vm = new NewDocumentViewModel();
+            var window = new NewDocumentWindow
+            {
+                DataContext = vm
+            };
+
+            bool? result = window.ShowDialog();
+            if (result == true)
+                return vm.SelectedType;
+
+            return null;
+        }
+    }
+}

--- a/source/ViewModels/MainWindowViewModel.cs
+++ b/source/ViewModels/MainWindowViewModel.cs
@@ -1,25 +1,38 @@
 using DevExpress.Mvvm;
 using Pulse.PLMSuite.Services;
+using Pulse.PLMSuite;
 
 namespace Pulse.PLMSuite.ViewModels
 {
     public class MainWindowViewModel : ViewModelBase
     {
         private readonly IMessageService _messageService;
+        private readonly INewDocumentDialogService _newDocumentDialogService;
+        private DocumentType? _currentDocumentType;
 
         public DelegateCommand NewCommand { get; }
 
-        public MainWindowViewModel(IMessageService messageService)
+        public DocumentType? CurrentDocumentType
+        {
+            get => _currentDocumentType;
+            set => SetProperty(ref _currentDocumentType, value);
+        }
+
+        public MainWindowViewModel(IMessageService messageService, INewDocumentDialogService newDocumentDialogService)
         {
             _messageService = messageService;
+            _newDocumentDialogService = newDocumentDialogService;
 
             NewCommand = new DelegateCommand(OnNew);
         }
 
         private void OnNew()
         {
-            // TODO: Implement new action logic
-            _messageService.Show("New command executed", "Info");
+            var type = _newDocumentDialogService.ShowDialog();
+            if (type.HasValue)
+            {
+                CurrentDocumentType = type.Value;
+            }
         }
     }
 }

--- a/source/ViewModels/NewDocumentViewModel.cs
+++ b/source/ViewModels/NewDocumentViewModel.cs
@@ -1,0 +1,37 @@
+using System;
+using DevExpress.Mvvm;
+
+namespace Pulse.PLMSuite.ViewModels
+{
+    public class NewDocumentViewModel : ViewModelBase
+    {
+        private DocumentType _selectedType;
+
+        public DocumentType SelectedType
+        {
+            get => _selectedType;
+            set => SetProperty(ref _selectedType, value);
+        }
+
+        public DelegateCommand OKCommand { get; }
+        public DelegateCommand CancelCommand { get; }
+
+        public NewDocumentViewModel()
+        {
+            OKCommand = new DelegateCommand(OnOk);
+            CancelCommand = new DelegateCommand(OnCancel);
+        }
+
+        public event Action<bool?>? CloseRequested;
+
+        private void OnOk()
+        {
+            CloseRequested?.Invoke(true);
+        }
+
+        private void OnCancel()
+        {
+            CloseRequested?.Invoke(false);
+        }
+    }
+}

--- a/source/Views/MainWindow.xaml.cs
+++ b/source/Views/MainWindow.xaml.cs
@@ -26,7 +26,7 @@ namespace Pulse.PLMSuite.Modeller.Views
         public MainWindow()
         {
             InitializeComponent();
-            DataContext = new MainWindowViewModel(new MessageService());
+            DataContext = new MainWindowViewModel(new MessageService(), new NewDocumentDialogService());
         }
     }
 }

--- a/source/Views/NewDocumentWindow.xaml
+++ b/source/Views/NewDocumentWindow.xaml
@@ -1,0 +1,16 @@
+<Window x:Class="Pulse.PLMSuite.Modeller.Views.NewDocumentWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="New Document" SizeToContent="WidthAndHeight"
+        WindowStartupLocation="CenterOwner">
+    <StackPanel Margin="10">
+        <TextBlock Text="Select document type:" Margin="0,0,0,5" />
+        <RadioButton x:Name="partRadio" Content="Part" GroupName="DocumentType" Margin="0,0,0,5" Checked="OnPartChecked"/>
+        <RadioButton x:Name="assemblyRadio" Content="Assembly" GroupName="DocumentType" Margin="0,0,0,5" Checked="OnAssemblyChecked"/>
+        <RadioButton x:Name="drawingRadio" Content="Drawing" GroupName="DocumentType" Margin="0,0,0,5" Checked="OnDrawingChecked"/>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+            <Button Content="OK" Width="75" Margin="0,0,5,0" IsDefault="True" Command="{Binding OKCommand}" />
+            <Button Content="Cancel" Width="75" IsCancel="True" Command="{Binding CancelCommand}" />
+        </StackPanel>
+    </StackPanel>
+</Window>

--- a/source/Views/NewDocumentWindow.xaml.cs
+++ b/source/Views/NewDocumentWindow.xaml.cs
@@ -1,0 +1,68 @@
+using System.Windows;
+using Pulse.PLMSuite;
+using Pulse.PLMSuite.ViewModels;
+
+namespace Pulse.PLMSuite.Modeller.Views
+{
+    public partial class NewDocumentWindow : Window
+    {
+        public NewDocumentWindow()
+        {
+            InitializeComponent();
+            Loaded += OnLoaded;
+        }
+
+        private void OnLoaded(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is NewDocumentViewModel vm)
+            {
+                vm.CloseRequested += Vm_CloseRequested;
+                UpdateSelection(vm.SelectedType);
+            }
+        }
+
+        private void Vm_CloseRequested(bool? result)
+        {
+            DialogResult = result;
+        }
+
+        private void OnPartChecked(object sender, RoutedEventArgs e)
+        {
+            SetType(DocumentType.Part);
+        }
+
+        private void OnAssemblyChecked(object sender, RoutedEventArgs e)
+        {
+            SetType(DocumentType.Assembly);
+        }
+
+        private void OnDrawingChecked(object sender, RoutedEventArgs e)
+        {
+            SetType(DocumentType.Drawing);
+        }
+
+        private void SetType(DocumentType type)
+        {
+            if (DataContext is NewDocumentViewModel vm)
+            {
+                vm.SelectedType = type;
+            }
+        }
+
+        private void UpdateSelection(DocumentType type)
+        {
+            switch (type)
+            {
+                case DocumentType.Part:
+                    partRadio.IsChecked = true;
+                    break;
+                case DocumentType.Assembly:
+                    assemblyRadio.IsChecked = true;
+                    break;
+                case DocumentType.Drawing:
+                    drawingRadio.IsChecked = true;
+                    break;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- support new document type enumeration
- add NewDocumentViewModel
- add NewDocumentWindow view
- implement NewDocumentDialogService
- update MainWindow to use the dialog and store the type

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683b04441798832e853d545438cb5c3e