### PR TITLE
Implement document creation workflow

### DIFF
--- a/source/App.xaml
+++ b/source/App.xaml
@@ -19,7 +19,9 @@
             xmlns:dxn="http://schemas.devexpress.com/winfx/2008/xaml/core/internal"
             xmlns:dxprg="http://schemas.devexpress.com/winfx/2008/xaml/propertygrid"
             xmlns:dxprgt="http://schemas.devexpress.com/winfx/2008/xaml/propertygrid/themekeys"
-            xmlns:sys="clr-namespace:System;assembly=mscorlib">
+            xmlns:sys="clr-namespace:System;assembly=mscorlib"
+            xmlns:vm="clr-namespace:Pulse.PLMSuite.ViewModels"
+            xmlns:views="clr-namespace:Pulse.PLMSuite.Modeller.Views">
 
             <!--  Converters  -->
 
@@ -562,6 +564,17 @@
                     </Setter.Value>
                 </Setter>
             </Style>
+
+            <!-- Document View Templates -->
+            <DataTemplate DataType="{x:Type vm:PartDocumentViewModel}">
+                <views:PartDocumentView />
+            </DataTemplate>
+            <DataTemplate DataType="{x:Type vm:AssemblyDocumentViewModel}">
+                <views:AssemblyDocumentView />
+            </DataTemplate>
+            <DataTemplate DataType="{x:Type vm:DrawingDocumentViewModel}">
+                <views:DrawingDocumentView />
+            </DataTemplate>
 
         </ResourceDictionary>
     </Application.Resources>

--- a/source/DocumentType.cs
+++ b/source/DocumentType.cs
@@ -1,0 +1,4 @@
+namespace Pulse.PLMSuite.Modeller
+{
+    public enum DocumentType { Part, Assembly, Drawing }
+}

--- a/source/Services/INewDocumentService.cs
+++ b/source/Services/INewDocumentService.cs
@@ -1,0 +1,7 @@
+namespace Pulse.PLMSuite.Modeller.Services
+{
+    public interface INewDocumentService
+    {
+        DocumentType? ShowDialog();
+    }
+}

--- a/source/Services/NewDocumentService.cs
+++ b/source/Services/NewDocumentService.cs
@@ -1,0 +1,22 @@
+using System.Windows;
+using Pulse.PLMSuite.Modeller.Views;
+using Pulse.PLMSuite.ViewModels;
+
+namespace Pulse.PLMSuite.Modeller.Services
+{
+    public class NewDocumentService : INewDocumentService
+    {
+        public DocumentType? ShowDialog()
+        {
+            var vm = new NewDocumentViewModel();
+            var window = new NewDocumentWindow
+            {
+                DataContext = vm,
+                Owner = Application.Current.MainWindow
+            };
+            vm.Close = r => window.DialogResult = r;
+            var result = window.ShowDialog();
+            return result == true ? vm.SelectedType : null;
+        }
+    }
+}

--- a/source/ViewModels/AssemblyDocumentViewModel.cs
+++ b/source/ViewModels/AssemblyDocumentViewModel.cs
@@ -1,0 +1,8 @@
+using DevExpress.Mvvm;
+
+namespace Pulse.PLMSuite.ViewModels
+{
+    public class AssemblyDocumentViewModel : ViewModelBase
+    {
+    }
+}

--- a/source/ViewModels/DrawingDocumentViewModel.cs
+++ b/source/ViewModels/DrawingDocumentViewModel.cs
@@ -1,0 +1,8 @@
+using DevExpress.Mvvm;
+
+namespace Pulse.PLMSuite.ViewModels
+{
+    public class DrawingDocumentViewModel : ViewModelBase
+    {
+    }
+}

--- a/source/ViewModels/MainWindowViewModel.cs
+++ b/source/ViewModels/MainWindowViewModel.cs
@@ -1,25 +1,50 @@
 using DevExpress.Mvvm;
 using Pulse.PLMSuite.Services;
+using Pulse.PLMSuite.Modeller;
+using Pulse.PLMSuite.Modeller.Services;
 
 namespace Pulse.PLMSuite.ViewModels
 {
     public class MainWindowViewModel : ViewModelBase
     {
         private readonly IMessageService _messageService;
+        private readonly INewDocumentService _newDocumentService;
+
+        private object _currentDocument;
+        public object CurrentDocument
+        {
+            get => _currentDocument;
+            set => SetProperty(ref _currentDocument, value, nameof(CurrentDocument));
+        }
 
         public DelegateCommand NewCommand { get; }
 
-        public MainWindowViewModel(IMessageService messageService)
+        public MainWindowViewModel(IMessageService messageService, INewDocumentService newDocumentService)
         {
             _messageService = messageService;
+            _newDocumentService = newDocumentService;
 
             NewCommand = new DelegateCommand(OnNew);
         }
 
         private void OnNew()
         {
-            // TODO: Implement new action logic
-            _messageService.Show("New command executed", "Info");
+            var type = _newDocumentService.ShowDialog();
+            if (type == null)
+                return;
+
+            switch (type)
+            {
+                case DocumentType.Part:
+                    CurrentDocument = new PartDocumentViewModel();
+                    break;
+                case DocumentType.Assembly:
+                    CurrentDocument = new AssemblyDocumentViewModel();
+                    break;
+                case DocumentType.Drawing:
+                    CurrentDocument = new DrawingDocumentViewModel();
+                    break;
+            }
         }
     }
 }

--- a/source/ViewModels/NewDocumentViewModel.cs
+++ b/source/ViewModels/NewDocumentViewModel.cs
@@ -1,0 +1,29 @@
+using DevExpress.Mvvm;
+using Pulse.PLMSuite.Modeller;
+using System;
+
+namespace Pulse.PLMSuite.ViewModels
+{
+    public class NewDocumentViewModel : ViewModelBase
+    {
+        public DocumentType? SelectedType { get; private set; }
+
+        public DelegateCommand<object> SelectCommand { get; }
+
+        public Action<bool?> Close { get; set; }
+
+        public NewDocumentViewModel()
+        {
+            SelectCommand = new DelegateCommand<object>(OnSelect);
+        }
+
+        private void OnSelect(object parameter)
+        {
+            if (parameter is DocumentType type)
+            {
+                SelectedType = type;
+                Close?.Invoke(true);
+            }
+        }
+    }
+}

--- a/source/ViewModels/PartDocumentViewModel.cs
+++ b/source/ViewModels/PartDocumentViewModel.cs
@@ -1,0 +1,8 @@
+using DevExpress.Mvvm;
+
+namespace Pulse.PLMSuite.ViewModels
+{
+    public class PartDocumentViewModel : ViewModelBase
+    {
+    }
+}

--- a/source/Views/AssemblyDocumentView.xaml
+++ b/source/Views/AssemblyDocumentView.xaml
@@ -1,0 +1,6 @@
+<UserControl x:Class="Pulse.PLMSuite.Modeller.Views.AssemblyDocumentView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:ctrl="clr-namespace:Pulse.PLMSuite.Modeller.Controls">
+    <ctrl:Viewport3D />
+</UserControl>

--- a/source/Views/DrawingDocumentView.xaml
+++ b/source/Views/DrawingDocumentView.xaml
@@ -1,0 +1,6 @@
+<UserControl x:Class="Pulse.PLMSuite.Modeller.Views.DrawingDocumentView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:ctrl="clr-namespace:Pulse.PLMSuite.Modeller.Controls">
+    <ctrl:Viewport2D />
+</UserControl>

--- a/source/Views/MainWindow.xaml
+++ b/source/Views/MainWindow.xaml
@@ -780,62 +780,7 @@
                                      ShowTabHeaders="False" >
                     <dxd:DocumentPanel Caption="Model Name">
                         <Grid>
-                            <ctrl:Viewport3D>
-                                <ddes:Design.ViewportBorder>
-                                    <ddes:BorderSettings Visible="False" />
-                                </ddes:Design.ViewportBorder>
-                                <ddes:Design.ProgressBar>
-                                    <ddes:ProgressBar Lighting="False" />
-                                </ddes:Design.ProgressBar>
-                                <ddes:Design.Viewports>
-                                    <ddes:Viewport DisplayMode="Rendered" InitialView="Dimetric">
-                                        <ddes:Viewport.Background>
-                                            <ddes:BackgroundSettings
-                                                BottomColor="#E9EEF1"
-                                                StyleMode="Solid"
-                                                TopColor="#E9EEF1" />
-                                        </ddes:Viewport.Background>
-                                        <ddes:Viewport.CoordinateSystemIcon>
-                                            <ddes:CoordinateSystemIcon Lighting="False" Visible="False" />
-                                        </ddes:Viewport.CoordinateSystemIcon>
-                                        <ddes:Viewport.Camera>
-                                            <Eyeshot:Camera
-                                                Distance="380"
-                                                FocalLength="40"
-                                                NearPlaneDistanceFactor="0.001"
-                                                ProjectionMode="Orthographic" />
-                                        </ddes:Viewport.Camera>
-                                        <ddes:Viewport.Grids>
-                                            <ddes:Grid
-                                                AutoSize="False"
-                                                Lighting="False"
-                                                Max="100, 100"
-                                                Min="-100, -100"
-                                                Step="10"
-                                                Visible="False" />
-                                        </ddes:Viewport.Grids>
-                                        <ddes:Viewport.OriginSymbols>
-                                            <ddes:OriginSymbol Lighting="False" Visible="False" />
-                                        </ddes:Viewport.OriginSymbols>
-                                        <ddes:Viewport.ToolBars>
-                                            <ddes:ToolBar Visible="False">
-                                                <ddes:ToolBar.Buttons>
-                                                    <ddes:HomeToolBarButton />
-                                                    <ddes:MagnifyingGlassToolBarButton />
-                                                    <ddes:ZoomWindowToolBarButton />
-                                                    <ddes:ZoomToolBarButton />
-                                                    <ddes:PanToolBarButton />
-                                                    <ddes:RotateToolBarButton />
-                                                    <ddes:ZoomFitToolBarButton />
-                                                </ddes:ToolBar.Buttons>
-                                            </ddes:ToolBar>
-                                        </ddes:Viewport.ToolBars>
-                                        <ddes:Viewport.ViewCubeIcon>
-                                            <ddes:ViewCubeIcon ShowShadow="False" Lighting="True" ShowRing="False" />
-                                        </ddes:Viewport.ViewCubeIcon>
-                                    </ddes:Viewport>
-                                </ddes:Design.Viewports>
-                            </ctrl:Viewport3D>
+                            <ContentControl Content="{Binding CurrentDocument}" />
                         </Grid>
                     </dxd:DocumentPanel>
                 </dxd:DocumentGroup>

--- a/source/Views/MainWindow.xaml.cs
+++ b/source/Views/MainWindow.xaml.cs
@@ -2,6 +2,7 @@
 using DevExpress.Xpf.Ribbon;
 using Pulse.PLMSuite.ViewModels;
 using Pulse.PLMSuite.Services;
+using Pulse.PLMSuite.Modeller.Services;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -26,7 +27,7 @@ namespace Pulse.PLMSuite.Modeller.Views
         public MainWindow()
         {
             InitializeComponent();
-            DataContext = new MainWindowViewModel(new MessageService());
+            DataContext = new MainWindowViewModel(new MessageService(), new NewDocumentService());
         }
     }
 }

--- a/source/Views/NewDocumentWindow.xaml
+++ b/source/Views/NewDocumentWindow.xaml
@@ -1,0 +1,13 @@
+<Window x:Class="Pulse.PLMSuite.Modeller.Views.NewDocumentWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="clr-namespace:Pulse.PLMSuite.Modeller"
+        Title="New Document" SizeToContent="WidthAndHeight"
+        WindowStartupLocation="CenterOwner">
+    <StackPanel Margin="20">
+        <TextBlock Text="Select Document Type:" Margin="0,0,0,10" />
+        <Button Content="Part" Command="{Binding SelectCommand}" CommandParameter="{x:Static local:DocumentType.Part}" Margin="0,0,0,5" />
+        <Button Content="Assembly" Command="{Binding SelectCommand}" CommandParameter="{x:Static local:DocumentType.Assembly}" Margin="0,0,0,5" />
+        <Button Content="Drawing" Command="{Binding SelectCommand}" CommandParameter="{x:Static local:DocumentType.Drawing}" />
+    </StackPanel>
+</Window>

--- a/source/Views/NewDocumentWindow.xaml.cs
+++ b/source/Views/NewDocumentWindow.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows;
+
+namespace Pulse.PLMSuite.Modeller.Views
+{
+    public partial class NewDocumentWindow : Window
+    {
+        public NewDocumentWindow()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/source/Views/PartDocumentView.xaml
+++ b/source/Views/PartDocumentView.xaml
@@ -1,0 +1,6 @@
+<UserControl x:Class="Pulse.PLMSuite.Modeller.Views.PartDocumentView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:ctrl="clr-namespace:Pulse.PLMSuite.Modeller.Controls">
+    <ctrl:Viewport3D />
+</UserControl>


### PR DESCRIPTION
## Summary
- define `DocumentType` enumeration
- implement `INewDocumentService` and `NewDocumentService`
- add `NewDocumentWindow` with buttons for part types
- create `PartDocumentViewModel`, `AssemblyDocumentViewModel` and `DrawingDocumentViewModel`
- add matching document views and link them via templates in `App.xaml`
- extend `MainWindowViewModel` to open the selection dialog and display the chosen document
- replace fixed viewport with `ContentControl` bound to `CurrentDocument`

## Testing
- `dotnet build source/Modeller.sln -c Release` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683b09df8ca4832e95a85ebfba014fc9