### PR TITLE
Enable multiple document tabs

### DIFF
--- a/source/ViewModels/MainWindowViewModel.cs
+++ b/source/ViewModels/MainWindowViewModel.cs
@@ -2,6 +2,7 @@ using DevExpress.Mvvm;
 using Pulse.PLMSuite.Services;
 using Pulse.PLMSuite.Modeller;
 using Pulse.PLMSuite.Modeller.Services;
+using System.Collections.ObjectModel;
 
 namespace Pulse.PLMSuite.ViewModels
 {
@@ -10,11 +11,12 @@ namespace Pulse.PLMSuite.ViewModels
         private readonly IMessageService _messageService;
         private readonly INewDocumentService _newDocumentService;
 
-        private object _currentDocument;
-        public object CurrentDocument
+        private object _selectedDocument;
+        public ObservableCollection<object> Documents { get; }
+        public object SelectedDocument
         {
-            get => _currentDocument;
-            set => SetProperty(ref _currentDocument, value, nameof(CurrentDocument));
+            get => _selectedDocument;
+            set => SetProperty(ref _selectedDocument, value, nameof(SelectedDocument));
         }
 
         public DelegateCommand NewCommand { get; }
@@ -24,6 +26,7 @@ namespace Pulse.PLMSuite.ViewModels
             _messageService = messageService;
             _newDocumentService = newDocumentService;
 
+            Documents = new ObservableCollection<object>();
             NewCommand = new DelegateCommand(OnNew);
         }
 
@@ -33,17 +36,24 @@ namespace Pulse.PLMSuite.ViewModels
             if (type == null)
                 return;
 
+            object document = null;
             switch (type)
             {
                 case DocumentType.Part:
-                    CurrentDocument = new PartDocumentViewModel();
+                    document = new PartDocumentViewModel();
                     break;
                 case DocumentType.Assembly:
-                    CurrentDocument = new AssemblyDocumentViewModel();
+                    document = new AssemblyDocumentViewModel();
                     break;
                 case DocumentType.Drawing:
-                    CurrentDocument = new DrawingDocumentViewModel();
+                    document = new DrawingDocumentViewModel();
                     break;
+            }
+
+            if (document != null)
+            {
+                Documents.Add(document);
+                SelectedDocument = document;
             }
         }
     }

--- a/source/Views/MainWindow.xaml
+++ b/source/Views/MainWindow.xaml
@@ -776,14 +776,13 @@
                 </dxd:LayoutPanel>
 
                 <!--  Document group for the viewport  -->
-                <dxd:DocumentGroup dxd:AutoHideGroup.IsAutoHideCenter="True" AllowDock="False" AllowFloat="False" AllowDrag="False"
-                                     ShowTabHeaders="False" >
-                    <dxd:DocumentPanel Caption="Model Name">
-                        <Grid>
-                            <ContentControl Content="{Binding CurrentDocument}" />
-                        </Grid>
-                    </dxd:DocumentPanel>
-                </dxd:DocumentGroup>
+                <dxd:DocumentGroup dxd:AutoHideGroup.IsAutoHideCenter="True"
+                                    AllowDock="False"
+                                    AllowFloat="False"
+                                    AllowDrag="False"
+                                    ItemsSource="{Binding Documents}"
+                                    SelectedItem="{Binding SelectedDocument}"
+                                    ShowTabHeaders="True" />
 
             </dxd:LayoutGroup>
         </dxd:DockLayoutManager>


### PR DESCRIPTION
## Summary
- manage opened documents in an `ObservableCollection`
- select documents via `SelectedDocument`
- show open documents in a tabbed `DocumentGroup`

## Testing
- `dotnet build source/Modeller.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683b13d4bfdc832eacbf0d364b6933d3