### PR TITLE
Add document models and bind to viewport

### DIFF
--- a/source/Documents/AssemblyDocument.cs
+++ b/source/Documents/AssemblyDocument.cs
@@ -1,0 +1,8 @@
+using devDept.Eyeshot;
+
+namespace Pulse.PLMSuite.Modeller.Documents
+{
+    public class AssemblyDocument : DesignDocument
+    {
+    }
+}

--- a/source/Documents/DrawingDocument.cs
+++ b/source/Documents/DrawingDocument.cs
@@ -1,0 +1,7 @@
+
+namespace Pulse.PLMSuite.Modeller.Documents
+{
+    public class DrawingDocument : devDept.Eyeshot.DrawingDocument
+    {
+    }
+}

--- a/source/Documents/PartDocument.cs
+++ b/source/Documents/PartDocument.cs
@@ -1,0 +1,8 @@
+using devDept.Eyeshot;
+
+namespace Pulse.PLMSuite.Modeller.Documents
+{
+    public class PartDocument : DesignDocument
+    {
+    }
+}

--- a/source/ViewModels/AssemblyDocumentViewModel.cs
+++ b/source/ViewModels/AssemblyDocumentViewModel.cs
@@ -1,8 +1,15 @@
 using DevExpress.Mvvm;
+using Pulse.PLMSuite.Modeller.Documents;
 
 namespace Pulse.PLMSuite.ViewModels
 {
     public class AssemblyDocumentViewModel : ViewModelBase
     {
+        public AssemblyDocument Document { get; }
+
+        public AssemblyDocumentViewModel()
+        {
+            Document = new AssemblyDocument();
+        }
     }
 }

--- a/source/ViewModels/DrawingDocumentViewModel.cs
+++ b/source/ViewModels/DrawingDocumentViewModel.cs
@@ -1,8 +1,15 @@
 using DevExpress.Mvvm;
+using Pulse.PLMSuite.Modeller.Documents;
 
 namespace Pulse.PLMSuite.ViewModels
 {
     public class DrawingDocumentViewModel : ViewModelBase
     {
+        public DrawingDocument Document { get; }
+
+        public DrawingDocumentViewModel()
+        {
+            Document = new DrawingDocument();
+        }
     }
 }

--- a/source/ViewModels/PartDocumentViewModel.cs
+++ b/source/ViewModels/PartDocumentViewModel.cs
@@ -1,8 +1,15 @@
 using DevExpress.Mvvm;
+using Pulse.PLMSuite.Modeller.Documents;
 
 namespace Pulse.PLMSuite.ViewModels
 {
     public class PartDocumentViewModel : ViewModelBase
     {
+        public PartDocument Document { get; }
+
+        public PartDocumentViewModel()
+        {
+            Document = new PartDocument();
+        }
     }
 }

--- a/source/Views/AssemblyDocumentView.xaml
+++ b/source/Views/AssemblyDocumentView.xaml
@@ -2,5 +2,5 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:ctrl="clr-namespace:Pulse.PLMSuite.Modeller.Controls">
-    <ctrl:Viewport3D />
+    <ctrl:Viewport3D Document="{Binding Document}" />
 </UserControl>

--- a/source/Views/DrawingDocumentView.xaml
+++ b/source/Views/DrawingDocumentView.xaml
@@ -2,5 +2,5 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:ctrl="clr-namespace:Pulse.PLMSuite.Modeller.Controls">
-    <ctrl:Viewport2D />
+    <ctrl:Viewport2D Document="{Binding Document}" />
 </UserControl>

--- a/source/Views/PartDocumentView.xaml
+++ b/source/Views/PartDocumentView.xaml
@@ -2,5 +2,5 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:ctrl="clr-namespace:Pulse.PLMSuite.Modeller.Controls">
-    <ctrl:Viewport3D />
+    <ctrl:Viewport3D Document="{Binding Document}" />
 </UserControl>


### PR DESCRIPTION
## Summary
- add simple document classes for part, assembly, and drawing
- expose a `Document` property in document viewmodels
- bind viewport controls to the new `Document` properties

## Testing
- `dotnet build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683b157eecbc832eba3ac12f528ce721