### PR TITLE
Add default DevExpress theme on startup

### DIFF
--- a/source/App.xaml.cs
+++ b/source/App.xaml.cs
@@ -1,8 +1,14 @@
 ﻿using System.Windows;
+using DevExpress.Xpf.Core;
 
 namespace Pulse.PLMSuite.Modeller
 {
     public partial class App : Application
     {
+        protected override void OnStartup(StartupEventArgs e)
+        {
+            ApplicationThemeHelper.ApplicationThemeName = Theme.Office2019WhiteName;
+            base.OnStartup(e);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- set up WPF startup to initialize DevExpress theme

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683b177d0520832ea228420b3c6cc7ac