### PR TITLE
Fix DocumentGroup active document binding

### DIFF
--- a/source/Views/MainWindow.xaml
+++ b/source/Views/MainWindow.xaml
@@ -781,7 +781,7 @@
                                     AllowFloat="False"
                                     AllowDrag="False"
                                     ItemsSource="{Binding Documents}"
-                                    SelectedItem="{Binding SelectedDocument}"
+                                    ActiveDockItem="{Binding SelectedDocument, Mode=TwoWay}"
                                     ShowTabHeaders="True" />
 
             </dxd:LayoutGroup>


### PR DESCRIPTION
## Summary
- bind `DocumentGroup.ActiveDockItem` to `SelectedDocument`

## Testing
- `msbuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683b1ab900bc832eb901465ac196d493